### PR TITLE
Replace scanf with getchar

### DIFF
--- a/src/APHeader.c
+++ b/src/APHeader.c
@@ -241,9 +241,12 @@ APHeader readAPHeader44DD55AA(FILE *f)
                     "  have the same format with different magic numbers.\n"
                     "  Do you want to assume that and try? Y/N : ");
 
-            scanf("%s", buf);
+            char c;
+            c = getchar();
+            while(getchar() != '\n')
+                ;
 
-            if (!(buf[0] == 'Y' || buf[0] == 'y')) break;
+            if (!(c == 'Y' || c == 'y')) break;
 
         case 0x8978f62b:
         case 0x5062c8ea:


### PR DESCRIPTION
The 'scanf' used in APHeader.c leaves a newline '\n' in the stdin
buffer that gets picked up by the next getchar() call. This
renders the calls to getchar() in BinExtractor.c to return \n
instead of y|Y or n|N
